### PR TITLE
fix bug in file DependencyTreeUtils.py

### DIFF
--- a/DockerImage/code/NlpUtils/DependencyTreeUtils.py
+++ b/DockerImage/code/NlpUtils/DependencyTreeUtils.py
@@ -68,7 +68,8 @@ def getDirectObjects(verb):
 	if dobj is not None:
 		conjs = []
 		for d in dobj:
-			getConjunctions(d, conjs)
+			# getConjunctions(d, conjs)
+			conjs.extend(getConjunctions(d))
 		for c in conjs:			
 			dobj.append(c)
 	return dobj


### PR DESCRIPTION
It seems that there is something wrong in function `get_direct_objects` in file `DockerImage/code/NlpUtils/DependencyTreeUtils.py`.
On line 71,  function `getConjunctions` is called with two parameters, while on line 14, there is only one parameter for function `getConjunctions`. I guess that you want to call `getConjunctionNPInternal`, but it is inside the function, it cannot be called directly. So I change the code to extend `conjs` defined on line 69 by calling `extend` method with value return from function `getConjunctions`.